### PR TITLE
Fix Inconsistent Path of "sfs" Folder

### DIFF
--- a/src/main/java/pignlproc/helpers/RestrictedNGramGenerator.java
+++ b/src/main/java/pignlproc/helpers/RestrictedNGramGenerator.java
@@ -90,6 +90,9 @@ public class RestrictedNGramGenerator extends EvalFunc<DataBag> {
 
         if (surfaceFormLookup.size() == 0) {
             File folder = new File("./sfs");
+            if(!folder.exists()) {
+                folder = new File(this.surfaceFormListFile);//local mode
+            }
             for (final File fileEntry: folder.listFiles()) {
                 if (fileEntry.getName().startsWith("part-")) {
                     FileReader fr = new FileReader(fileEntry);


### PR DESCRIPTION
The path of sfs folder is defined by user in names_and_entities.pig.params. But "./sfs" is used as the path of sfs folder here,which may cause the following error:

java.lang.NullPointerException
    at pignlproc.helpers.RestrictedNGramGenerator.exec(RestrictedNGramGenerator.java:98)
    at pignlproc.helpers.RestrictedNGramGenerator.exec(RestrictedNGramGenerator.java:44)
    at org.apache.pig.backend.hadoop.executionengine.physicalLayer.expressionOperators.POUserFunc.getNext(POUserFunc.java:337)
    at org.apache.pig.backend.hadoop.executionengine.physicalLayer.expressionOperators.POUserFunc.getNext(POUserFunc.java:381)
